### PR TITLE
feat(observability): add OpenTelemetry distributed tracing

### DIFF
--- a/Notice.txt
+++ b/Notice.txt
@@ -1,5 +1,5 @@
 
-Lists of 17 third-party dependencies.
+Lists of 18 third-party dependencies.
      (Apache License Version 2.0) Vaadin Quarkus Extension (com.vaadin:vaadin-quarkus-extension:24.9.7 - https://vaadin.com/vaadin-quarkus-extension-parent/vaadin-quarkus-extension)
      (Apache License, Version 2.0) PDFBox-Graphics2d (de.rototor.pdfbox:graphics2d:3.0.2 - https://github.com/rototor/pdfbox-graphics2d/graphics2d)
      (Apache License, Version 2.0) Quarkus PDFBox - Runtime (io.quarkiverse.pdfbox:quarkus-pdfbox:1.2.0 - https://quarkiverse.io)
@@ -11,6 +11,7 @@ Lists of 17 third-party dependencies.
      (The Apache Software License, Version 2.0) Quarkus - JDBC - PostgreSQL - Runtime (io.quarkus:quarkus-jdbc-postgresql:3.30.3 - https://github.com/quarkusio/quarkus)
      (The Apache Software License, Version 2.0) Quarkus - Logging - JSON - Runtime (io.quarkus:quarkus-logging-json:3.30.3 - https://github.com/quarkusio/quarkus)
      (The Apache Software License, Version 2.0) Quarkus - Micrometer Registry - Prometheus Runtime (io.quarkus:quarkus-micrometer-registry-prometheus:3.30.3 - https://github.com/quarkusio/quarkus)
+     (The Apache Software License, Version 2.0) Quarkus - OpenTelemetry - Runtime (io.quarkus:quarkus-opentelemetry:3.30.3 - https://github.com/quarkusio/quarkus)
      (The Apache Software License, Version 2.0) Quarkus - REST - Runtime (io.quarkus:quarkus-rest:3.30.3 - https://github.com/quarkusio/quarkus)
      (The Apache Software License, Version 2.0) Quarkus - REST Client - Runtime (io.quarkus:quarkus-rest-client:3.30.3 - https://github.com/quarkusio/quarkus)
      (The Apache Software License, Version 2.0) Quarkus - REST Client JSON-B (io.quarkus:quarkus-rest-client-jsonb:3.30.3 - https://github.com/quarkusio/quarkus)

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
 <groupId>com.elicitsoftware</groupId>
     <artifactId>survey</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.1-SNAPSHOT</version>
 
     <properties>
         <compiler-plugin.version>3.14.0</compiler-plugin.version>
@@ -80,6 +80,10 @@
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
         <!-- Observability Stack -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-opentelemetry</artifactId>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-micrometer-registry-prometheus</artifactId>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -52,7 +52,67 @@ quarkus.micrometer.binder.http-server.max-uri-tags=100
 quarkus.micrometer.binder.http-server.ignore-patterns=/q/.*
 
 # Connection Pool Metrics
-quarkus.datasource.jdbc.enable-metrics=true
+# Note: Connection pool metrics are enabled via quarkus.datasource.jdbc.metrics.enabled above
+
+# =============================================================================
+# OPENTELEMETRY CONFIGURATION
+# =============================================================================
+
+# Enable OpenTelemetry
+quarkus.otel.enabled=true
+
+# Application/Service Name for OpenTelemetry Resource Attributes
+quarkus.otel.service.name=${quarkus.application.name}
+
+# Tracing Configuration (enabled by default)
+quarkus.otel.traces.enabled=true
+quarkus.otel.traces.sampler=parentbased_always_on
+quarkus.otel.traces.suppress-non-application-uris=true
+
+# Metrics Configuration (experimental - enable if needed)
+# quarkus.otel.metrics.enabled=true
+# quarkus.otel.metric.export.interval=60s
+
+# Logs Configuration (experimental - enable if needed)
+# quarkus.otel.logs.enabled=true
+
+# OTLP Exporter Configuration
+# Default endpoint is http://localhost:4317 for gRPC
+quarkus.otel.exporter.otlp.endpoint=http://localhost:4317
+quarkus.otel.exporter.otlp.protocol=grpc
+
+# Optional: Authentication headers for OTLP endpoint
+# quarkus.otel.exporter.otlp.headers=authorization=Bearer <token>
+
+# Optional: Compression (gzip or none)
+# quarkus.otel.exporter.otlp.compression=gzip
+
+# Add trace context to console logs
+quarkus.log.console.format=%d{HH:mm:ss} %-5p traceId=%X{traceId}, parentId=%X{parentId}, spanId=%X{spanId}, sampled=%X{sampled} [%c{2.}] (%t) %s%e%n
+
+# Instrumentation Configuration
+quarkus.otel.instrument.vertx-http=true
+quarkus.otel.instrument.vertx-event-bus=true
+quarkus.otel.instrument.vertx-sql-client=true
+quarkus.otel.instrument.rest=true
+quarkus.otel.instrument.resteasy=true
+
+# Resource Attributes
+quarkus.otel.resource.attributes=deployment.environment=${DEPLOYMENT_ENV:dev}
+
+# Propagators (W3C Trace Context and Baggage by default)
+quarkus.otel.propagators=tracecontext,baggage
+
+# Span Limits
+quarkus.otel.span.attribute.count.limit=128
+quarkus.otel.span.event.count.limit=128
+quarkus.otel.span.link.count.limit=128
+
+# Batch Span Processor Configuration
+quarkus.otel.bsp.schedule.delay=5s
+quarkus.otel.bsp.max.queue.size=2048
+quarkus.otel.bsp.max.export.batch.size=512
+quarkus.otel.bsp.export.timeout=30s
 
 # Vaadin
 quarkus.index-dependency.elicit.group-id=com.elicitsoftware


### PR DESCRIPTION
- Add quarkus-opentelemetry dependency to pom.xml
- Configure OpenTelemetry in application.properties with:
  - OTLP gRPC exporter (localhost:4317)
  - Automatic instrumentation for HTTP, REST, Vert.x, SQL
  - Trace context in console logs (traceId, spanId, parentId)
  - Service name: elicit-survey
  - Resource attributes and propagators
- Remove invalid datasource property (quarkus.datasource.jdbc.enable-metrics)
- Create OPENTELEMETRY_SETUP.md with complete configuration guide
- Enhance METRICS_GUIDE.md with OpenTelemetry sections:
  - Trace visualization with Jaeger
  - Common trace patterns (N+1 queries, latency, contention)
  - Correlating traces with metrics
  - Google Cloud Trace integration
  - Local testing instructions
- Update Notice.txt with new dependency licenses
- Bump version to 1.2.1-SNAPSHOT

OpenTelemetry provides distributed tracing to complement Micrometer metrics, enabling detailed request flow visualization for diagnosing the 10x cloud performance degradation. Use metrics to detect issues, traces to diagnose them.